### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Let's use an example to walk through the list.
 
 ### Fork Your Own Branch
 
-There are many PolarDB-X related repositories, take PolarDB-X SQL and PolarDB-X Glue for an example. On Github page of [PolarDB-X SQL](https://github.com/polardb/polardbx-sql) and [PolarDB-X Glue](https://github.com/polardbx/polardbx-glue), Click **fork** button to create your own polardbx-sql and polardbx-glue repository.
+There are many PolarDB-X related repositories, take PolarDB-X SQL and PolarDB-X Glue for an example. On Github page of [PolarDB-X SQL](https://github.com/polardb/polardbx-sql) and [PolarDB-X Glue](https://github.com/polardb/polardbx-glue), Click **fork** button to create your own polardbx-sql and polardbx-glue repository.
 
 ### Create Local Repository
 ```bash


### PR DESCRIPTION
Fix the wrong link address of PolarDB-X Glue

# Problems solved in this PR
The link address of PolarDB-X is wrong
# Changes proposed in this PR
Fix the wrong link address of PolarDB-X Glue
# Tests
- [ ] Unit test
- [ ] DML_DDL test

## Release note
> None
