### PR TITLE
support patition hint patch

### DIFF
--- a/polardbx-common/src/main/java/com/alibaba/polardbx/common/exception/code/ErrorCode.java
+++ b/polardbx-common/src/main/java/com/alibaba/polardbx/common/exception/code/ErrorCode.java
@@ -186,6 +186,8 @@ public enum ErrorCode {
      */
     ERR_TABLE_EMPTY_WITH_HINT(ErrorType.Optimizer, 4528),
 
+    ERR_PARTITION_HINT(ErrorType.Optimizer, 4529),
+
     // ============= executor 从4600下标开始================
     //
     ERR_FUNCTION(ErrorType.Executor, 4600),

--- a/polardbx-common/src/main/resources/res/ErrorCode.properties
+++ b/polardbx-common/src/main/resources/res/ErrorCode.properties
@@ -53,6 +53,7 @@ ERR_MODIFY_SHARD_COLUMN=Column ''{0}'' is a sharding key of table ''{1}'', which
 ERR_PK_WRITER_ON_TABLE_WITHOUT_PK=Cannot create Pk{0}Writer on table ''{1}'' which has no primary key.
 ERR_MODIFY_SHARD_COLUMN_ON_TABLE_WITHOUT_PK=Cannot update sharding key on table ''{1}'' which has no primary key.
 ERR_TABLE_EMPTY_WITH_HINT=Sql with Hint is not used correctly, no physical table will execute sql.
+ERR_PARTITION_HINT={0}
 ERR_MODIFY_PRIMARY_KEY=Column ''{0}'' is primary key, which is forbidden to be modified.
 ERR_QUERY_CANCLED=Getting connection is not allowed when query has been cancled, group is {0}
 ERR_MODIFY_SYSTEM_TABLE=Table ''{0}'' is DRDS SYSTEM TABLE, which is forbidden to be modified.

--- a/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/context/ExecutionContext.java
+++ b/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/context/ExecutionContext.java
@@ -401,7 +401,9 @@ public class ExecutionContext {
 
     private CalcitePlanOptimizerTrace calcitePlanOptimizerTrace;
 
-    private String partitionName;
+    private String partitionHint;
+
+    private boolean visitDBBuildIn;
 
     public ExecutionContext() {
     }
@@ -860,12 +862,20 @@ public class ExecutionContext {
         return rs;
     }
 
-    public String getPartitionName() {
-        return partitionName;
+    public String getPartitionHint() {
+        return partitionHint;
     }
 
-    public void setPartitionName(String partitionName) {
-        this.partitionName = partitionName;
+    public void setPartitionHint(String partitionHint) {
+        this.partitionHint = partitionHint;
+    }
+
+    public boolean isVisitDBBuildIn() {
+        return visitDBBuildIn;
+    }
+
+    public void setVisitDBBuildIn(boolean visitDBBuildIn) {
+        this.visitDBBuildIn = visitDBBuildIn;
     }
 
     public static class ErrorMessage {

--- a/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/core/planner/Planner.java
+++ b/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/core/planner/Planner.java
@@ -718,9 +718,11 @@ public class Planner {
         }
 
         if (hintCollection.pushdownOriginSql() ||
-            (StringUtils.isNotEmpty(ec.getPartitionName()) && (ast.isA(DML) || ast.isA(QUERY))
-                && isSuitableForDirectMode(explain))
-        ) {
+            (StringUtils.isNotEmpty(ec.getPartitionHint()) &&
+                (ast.isA(DML) || ast.isA(QUERY)) &&
+                isSuitableForDirectMode(explain) &&
+                !ec.isVisitDBBuildIn()
+            )) {
             executionPlan = hintPlanner.direct(ast, cmdBean, hintCollection, param, ec.getSchemaName(), ec);
         } else if (hintCollection.cmdOnly() || hintCollection.errorMessages.size() > 0) {
             //FIXME here task the illegal hint as the cmd hint.

--- a/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/core/rel/ReplaceTblWithPhyTblVisitor.java
+++ b/polardbx-optimizer/src/main/java/com/alibaba/polardbx/optimizer/core/rel/ReplaceTblWithPhyTblVisitor.java
@@ -18,31 +18,31 @@ package com.alibaba.polardbx.optimizer.core.rel;
 
 import com.alibaba.polardbx.common.exception.TddlRuntimeException;
 import com.alibaba.polardbx.common.exception.code.ErrorCode;
-import com.alibaba.polardbx.common.properties.ConnectionParams;
-import com.alibaba.polardbx.common.properties.ConnectionProperties;
+import com.alibaba.polardbx.common.utils.Assert;
+import com.alibaba.polardbx.common.utils.CaseInsensitive;
+import com.alibaba.polardbx.common.utils.Pair;
 import com.alibaba.polardbx.config.ConfigDataMode;
-import com.alibaba.polardbx.gms.topology.DbInfoManager;
 import com.alibaba.polardbx.optimizer.OptimizerContext;
 import com.alibaba.polardbx.optimizer.config.table.TableMeta;
 import com.alibaba.polardbx.optimizer.context.ExecutionContext;
 import com.alibaba.polardbx.optimizer.partition.PartitionInfo;
-import com.alibaba.polardbx.optimizer.partition.PartitionInfoManager;
 import com.alibaba.polardbx.optimizer.partition.pruning.PhysicalPartitionInfo;
 import com.alibaba.polardbx.optimizer.rule.TddlRuleManager;
 import com.alibaba.polardbx.rule.TableRule;
 import com.clearspring.analytics.util.Lists;
-import com.google.common.base.Preconditions;
 import org.apache.calcite.sql.SqlDelete;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.commons.lang.StringUtils;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class ReplaceTblWithPhyTblVisitor extends ReplaceTableNameWithSomethingVisitor {
 
@@ -50,14 +50,22 @@ public class ReplaceTblWithPhyTblVisitor extends ReplaceTableNameWithSomethingVi
     private boolean withSingleTbl;
     private boolean withPartitionTbl;
     private String uniqGroupName;
+    private boolean isPartitionHint;
 
-    public ReplaceTblWithPhyTblVisitor(String defaultSchemaName,
-                                       ExecutionContext executionContext) {
+    private String broadcastGroupName;
+    private int shardingNum = -1;
+    private long tableGroupId = -1;
+
+    public ReplaceTblWithPhyTblVisitor(String defaultSchemaName, ExecutionContext executionContext,
+                                       boolean hasDirectHint) {
         super(defaultSchemaName, executionContext);
         //Preconditions.checkArgument(!DbInfoManager.getInstance().isNewPartitionDb(defaultSchemaName));
         this.schemaName = defaultSchemaName;
         this.withSingleTbl = false;
         this.withPartitionTbl = false;
+        if (!hasDirectHint && StringUtils.isNotEmpty(executionContext.getPartitionHint())) {
+            isPartitionHint = true;
+        }
     }
 
     @Override
@@ -68,21 +76,46 @@ public class ReplaceTblWithPhyTblVisitor extends ReplaceTableNameWithSomethingVi
         if (!(sqlNode instanceof SqlIdentifier)) {
             return sqlNode;
         }
-        final String logicalTableName = ((SqlIdentifier) sqlNode).getLastName();
 
+        List<String> names = ((SqlIdentifier) sqlNode).names;
+        assert names.size() != 0;
+        final String logicalTableName = names.get(names.size() - 1);
+        if (isPartitionHint && names.size() > 1) {
+            String schema = names.get(names.size() - 2);
+            if (StringUtils.isNotEmpty(schema) && !schemaName.equalsIgnoreCase(schema)) {
+                throw new TddlRuntimeException(ErrorCode.ERR_PARTITION_HINT,
+                    "partition hint visit table crossing schema");
+            }
+        }
         TddlRuleManager tddlRuleManager = OptimizerContext.getContext(schemaName).getRuleManager();
         if (tddlRuleManager == null) {
             return sqlNode;
         }
-        String pName = ec.getPartitionName();
+        String pHint = ec.getPartitionHint();
         final TableRule tableRule = tddlRuleManager.getTableRule(logicalTableName);
-        if (tableRule == null) {
-            if (pName != null && !pName.isEmpty()) {
+        if (isPartitionHint) {
+            Assert.assertTrue(StringUtils.isNotEmpty(pHint));
+            if (tableRule == null) {
                 TableMeta tb =
                     OptimizerContext.getContext(schemaName).getLatestSchemaManager().getTable(logicalTableName);
+                Assert.assertTrue(tb != null);
+                // auto table
                 PartitionInfo pi = tb.getPartitionInfo();
+                if (pi.isGsiBroadcastOrBroadcast()) {
+                    broadcastGroupName = pi.defaultDbIndex();
+                    String physicalTblName =
+                        pi.getPhysicalPartitionTopology(null).values().iterator().next().get(0).getPhyTable();
+                    return new SqlIdentifier(physicalTblName, SqlParserPos.ZERO);
+                }
+                // record and check table group id
+                if (tableGroupId == -1L) {
+                    tableGroupId = pi.getTableGroupId();
+                } else if (tableGroupId != pi.getTableGroupId()) {
+                    throw new TddlRuntimeException(ErrorCode.ERR_PARTITION_HINT,
+                        "different table group in partition hint mode");
+                }
                 List<String> partitionList = Lists.newArrayList();
-                partitionList.add(pName);
+                partitionList.add(pHint);
                 Map<String, List<PhysicalPartitionInfo>> physicalPartitionInfos =
                     pi.getPhysicalPartitionTopology(partitionList);
                 if (physicalPartitionInfos != null && physicalPartitionInfos.size() == 1) {
@@ -95,6 +128,7 @@ public class ReplaceTblWithPhyTblVisitor extends ReplaceTableNameWithSomethingVi
                         } else {
                             // error
                             if (!uniqGroupName.equalsIgnoreCase(groupName)) {
+                                // should not happen
                                 throw new TddlRuntimeException(ErrorCode.ERR_NOT_SUPPORT,
                                     "Unsupported to use direct HINT for multi partition");
                             }
@@ -103,11 +137,46 @@ public class ReplaceTblWithPhyTblVisitor extends ReplaceTableNameWithSomethingVi
                         return new SqlIdentifier(physicalTblName, SqlParserPos.ZERO);
                     }
                 } else {
-                    throw new TddlRuntimeException(ErrorCode.ERR_NOT_SUPPORT,
+                    // should not happen
+                    throw new TddlRuntimeException(ErrorCode.ERR_PARTITION_HINT,
                         "Unsupported to use direct HINT for part table that has multi physical tables in one partition");
                 }
-            }
 
+                return sqlNode;
+            } else {
+                // drds table partition hint: groupname_xxxx
+                Pair<String, Integer> topologyTarget = decodePartitionHintForShardingTable(pHint);
+                uniqGroupName = topologyTarget.getKey();
+                Map<String, Set<String>> topology = new TreeMap<>(CaseInsensitive.CASE_INSENSITIVE_ORDER);
+                topology.putAll(tableRule.getActualTopology());
+                if (topology.containsKey(topologyTarget.getKey())) {
+                    Assert.assertTrue(topology.get(topologyTarget.getKey()) != null);
+                    String[] tbls = topology.get(topologyTarget.getKey()).toArray(new String[0]);
+
+                    // record and check shardingNum
+                    if (shardingNum == -1) {
+                        shardingNum = tbls.length;
+                    } else if (shardingNum != tbls.length) {
+                        throw new TddlRuntimeException(ErrorCode.ERR_PARTITION_HINT,
+                            "different sharding table num in partition hint mode");
+                    }
+
+                    Arrays.sort(tbls, CaseInsensitive.CASE_INSENSITIVE_ORDER);
+                    if (topologyTarget.getValue() < tbls.length) {
+                        String physicalTblName = tbls[topologyTarget.getValue()];
+                        return new SqlIdentifier(physicalTblName, SqlParserPos.ZERO);
+                    } else {
+                        throw new TddlRuntimeException(ErrorCode.ERR_PARTITION_HINT,
+                            "table index overflow in target group from direct HINT for sharding table");
+                    }
+                } else {
+                    throw new TddlRuntimeException(ErrorCode.ERR_PARTITION_HINT,
+                        "cannot find target group from direct HINT for sharding table");
+                }
+            }
+        }
+
+        if (tableRule == null) {
             return sqlNode;
         }
         // don't replace table with sharding db and  tb
@@ -118,18 +187,28 @@ public class ReplaceTblWithPhyTblVisitor extends ReplaceTableNameWithSomethingVi
                 }
             }
         }
-        if (pName != null && !pName.isEmpty()) {
-            if (uniqGroupName == null) {
-                uniqGroupName = pName;
-            } else {
-                // error
-            }
-        }
 
         this.withSingleTbl |= tddlRuleManager.isTableInSingleDb(logicalTableName);
         this.withPartitionTbl |= tddlRuleManager.isShard(logicalTableName);
 
         return new SqlIdentifier(tableRule.getTbNamePattern(), SqlParserPos.ZERO);
+    }
+
+    /**
+     * partition hint decode for sharding table
+     * groupname_00xx
+     */
+    private Pair<String, Integer> decodePartitionHintForShardingTable(String pHint) {
+        int split = pHint.lastIndexOf(':');
+        String gName = pHint;
+        Integer tblNum = 0;
+        if (split != -1) {
+            gName = pHint.substring(0, split);
+            tblNum = Integer.parseInt(pHint.substring(split + 1));
+        }
+
+        Pair<String, Integer> gNameTblNum = new Pair<>(gName, tblNum);
+        return gNameTblNum;
     }
 
     @Override
@@ -154,6 +233,9 @@ public class ReplaceTblWithPhyTblVisitor extends ReplaceTableNameWithSomethingVi
     }
 
     public String getUniqGroupName() {
+        if (StringUtils.isEmpty(uniqGroupName)) {
+            return broadcastGroupName;
+        }
         return uniqGroupName;
     }
 }

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/matrix/jdbc/TConnection.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/matrix/jdbc/TConnection.java
@@ -1108,7 +1108,7 @@ public class TConnection implements ITConnection {
         PreparedStmtCache preparedStmtCache = null;
         DdlContext ddlContext = null;
         boolean usingHint = false;
-        String partitionName = null;
+        String partitionHint = null;
 
         if (this.executionContext != null) {
             privilegeContext = this.executionContext.getPrivilegeContext();
@@ -1123,7 +1123,7 @@ public class TConnection implements ITConnection {
             preparedStmtCache = this.executionContext.getPreparedStmtCache();
             ddlContext = this.executionContext.getDdlContext();
             usingHint = this.executionContext.isUseHint();
-            partitionName = this.executionContext.getPartitionName();
+            partitionHint = this.executionContext.getPartitionHint();
         }
         if (privilegeContext == null) {
             privilegeContext = new PrivilegeContext();
@@ -1171,7 +1171,7 @@ public class TConnection implements ITConnection {
         this.executionContext.setOptimizedWithReturning(false);
         this.executionContext.setClientFoundRows(isClientFoundRows());
         this.executionContext.setUseHint(usingHint);
-        this.executionContext.setPartitionName(partitionName);
+        this.executionContext.setPartitionHint(partitionHint);
 
         this.executionContext.setIsExecutingPreparedStmt(isExecutingPreparedStmt);
         this.executionContext.setPreparedStmtCache(preparedStmtCache);

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/server/ServerConnection.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/server/ServerConnection.java
@@ -294,7 +294,7 @@ public final class ServerConnection extends FrontendConnection implements Resche
     private volatile RescheduleParam rescheduleParam;
     private volatile RescheduleTask rescheduleTask;
     private ExecInfo execInfo;
-    private String partitionName;
+    private String partitionHint;
 
     /**
      * Session's active roles.
@@ -1485,8 +1485,8 @@ public final class ServerConnection extends FrontendConnection implements Resche
         ec.setSchemaName(schema);
         ec.setClientFoundRows(clientFoundRows());
         ec.setTxIsolation(this.txIsolation);
-        ec.setPartitionName(partitionName);
-        if (StringUtils.isNotEmpty(partitionName)) {
+        ec.setPartitionHint(partitionHint);
+        if (StringUtils.isNotEmpty(partitionHint)) {
             ec.setUseHint(true);
         }
 
@@ -2254,8 +2254,12 @@ public final class ServerConnection extends FrontendConnection implements Resche
         }
     }
 
-    public void setPartitionName(String partitionName) {
-        this.partitionName = partitionName;
+    public void setPartitionHint(String partitionHint) {
+        this.partitionHint = partitionHint;
+    }
+
+    public String getPartitionHint() {
+        return partitionHint;
     }
 
     /**

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/server/handler/SetHandler.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/server/handler/SetHandler.java
@@ -364,8 +364,8 @@ public final class SetHandler {
                         // ignore max_statement_time for 2.0
                     } else if ("MAX_STATEMENT_TIME".equalsIgnoreCase(key.getName())) {
                         // ignore max_statement_time for 2.0
-                    } else if ("PARTITION_NAME".equalsIgnoreCase(key.getName())) {
-                        c.setPartitionName(RelUtils.stringValue(oriValue));
+                    } else if ("PARTITION_HINT".equalsIgnoreCase(key.getName())) {
+                        c.setPartitionHint(RelUtils.stringValue(oriValue));
                     } else if ("TRANSACTION POLICY".equalsIgnoreCase(key.getName())) {
                         if (!(oriValue instanceof SqlNumericLiteral) &&
                             !(oriValue instanceof SqlUserDefVar) && !(oriValue instanceof SqlSystemVar)) {

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/server/handler/ShowHandler.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/server/handler/ShowHandler.java
@@ -23,6 +23,8 @@ import com.alibaba.polardbx.server.response.ShowCacheStats;
 import com.alibaba.polardbx.server.response.ShowConnection;
 import com.alibaba.polardbx.server.response.ShowDatabases;
 import com.alibaba.polardbx.server.response.ShowErrors;
+import com.alibaba.polardbx.server.response.ShowFileStorage;
+import com.alibaba.polardbx.server.response.ShowFullConnection;
 import com.alibaba.polardbx.server.response.ShowFullDatabases;
 import com.alibaba.polardbx.server.response.ShowFileStorage;
 import com.alibaba.polardbx.server.response.ShowGitCommit;
@@ -105,6 +107,9 @@ public final class ShowHandler {
                 break;
             case ServerParseShow.FULL_DATABASES:
                 ShowFullDatabases.response(c, hasMore);
+                break;
+            case ServerParseShow.FULL_CONNECTION:
+                ShowFullConnection.execute(c, hasMore);
                 break;
             default:
                 c.execute(stmt, hasMore);

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/server/response/ShowConnectionSyncAction.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/server/response/ShowConnectionSyncAction.java
@@ -77,6 +77,7 @@ public class ShowConnectionSyncAction implements ISyncAction {
         result.addColumn("CHANNELS", DataTypes.IntegerType);
         result.addColumn("TRX", DataTypes.IntegerType);
         result.addColumn("NEED_RECONNECT", DataTypes.IntegerType);
+        result.addColumn("PARTITION_HINT", DataTypes.StringType);
 
         for (NIOProcessor p : CobarServer.getInstance().getProcessors()) {
             for (FrontendConnection fc : p.getFrontends().values()) {
@@ -107,7 +108,7 @@ public class ShowConnectionSyncAction implements ISyncAction {
                             fc.getCharset(), fc.getNetInBytes(), fc.getNetOutBytes(),
                             (TimeUtil.currentTimeMillis() - fc.getStartupTime()) / 1000L,
                             (System.nanoTime() - sc.getLastActiveTime()) / (1000 * 1000), count, trx,
-                            needReconnect});
+                            needReconnect, sc.getPartitionHint()});
 
                 }
             }

--- a/polardbx-server/src/main/java/com/alibaba/polardbx/server/response/ShowFullConnection.java
+++ b/polardbx-server/src/main/java/com/alibaba/polardbx/server/response/ShowFullConnection.java
@@ -1,0 +1,165 @@
+package com.alibaba.polardbx.server.response;
+
+import com.alibaba.polardbx.ErrorCode;
+import com.alibaba.polardbx.Fields;
+import com.alibaba.polardbx.config.SchemaConfig;
+import com.alibaba.polardbx.executor.sync.SyncManagerHelper;
+import com.alibaba.polardbx.matrix.jdbc.TDataSource;
+import com.alibaba.polardbx.net.buffer.ByteBufferHolder;
+import com.alibaba.polardbx.net.compress.IPacketOutputProxy;
+import com.alibaba.polardbx.net.compress.PacketOutputProxyFactory;
+import com.alibaba.polardbx.net.packet.EOFPacket;
+import com.alibaba.polardbx.net.packet.FieldPacket;
+import com.alibaba.polardbx.net.packet.MySQLPacket;
+import com.alibaba.polardbx.net.packet.ResultSetHeaderPacket;
+import com.alibaba.polardbx.net.packet.RowDataPacket;
+import com.alibaba.polardbx.optimizer.OptimizerContext;
+import com.alibaba.polardbx.optimizer.core.datatype.DataTypes;
+import com.alibaba.polardbx.server.ServerConnection;
+import com.alibaba.polardbx.server.util.IntegerUtil;
+import com.alibaba.polardbx.server.util.LongUtil;
+import com.alibaba.polardbx.server.util.PacketUtil;
+import com.alibaba.polardbx.server.util.StringUtil;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * connections command with extra info, like partition hint
+ */
+public final class ShowFullConnection {
+
+    private static final int FIELD_COUNT = 14;
+    private static final ResultSetHeaderPacket header = PacketUtil.getHeader(FIELD_COUNT);
+    private static final FieldPacket[] fields = new FieldPacket[FIELD_COUNT];
+    private static final EOFPacket eof = new EOFPacket();
+
+    static {
+        int i = 0;
+        byte packetId = 0;
+        header.packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("ID", Fields.FIELD_TYPE_VAR_STRING);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("HOST", Fields.FIELD_TYPE_VAR_STRING);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("PORT", Fields.FIELD_TYPE_LONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("LOCAL_PORT", Fields.FIELD_TYPE_LONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("SCHEMA", Fields.FIELD_TYPE_VAR_STRING);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("CHARSET", Fields.FIELD_TYPE_VAR_STRING);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("NET_IN", Fields.FIELD_TYPE_LONGLONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("NET_OUT", Fields.FIELD_TYPE_LONGLONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("ALIVE_TIME(s)", Fields.FIELD_TYPE_LONGLONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("LAST_ACTIVE(ms)", Fields.FIELD_TYPE_LONGLONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("CHANNELS", Fields.FIELD_TYPE_LONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("TRX", Fields.FIELD_TYPE_LONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("NEED_RECONNECT", Fields.FIELD_TYPE_LONG);
+        fields[i++].packetId = ++packetId;
+
+        fields[i] = PacketUtil.getField("PARTITION_HINT", Fields.FIELD_TYPE_VAR_STRING);
+        fields[i].packetId = ++packetId;
+
+        eof.packetId = ++packetId;
+    }
+
+    public static boolean execute(ServerConnection c, boolean hasMore) {
+        ByteBufferHolder buffer = c.allocate();
+        IPacketOutputProxy proxy = PacketOutputProxyFactory.getInstance().createProxy(c, buffer);
+        proxy.packetBegin();
+
+        // write header
+        proxy = header.write(proxy);
+
+        // write fields
+        for (FieldPacket field : fields) {
+            proxy = field.write(proxy);
+        }
+
+        // write eof
+        proxy = eof.write(proxy);
+
+        // write rows
+        byte packetId = eof.packetId;
+        String charset = c.getCharset();
+
+        SchemaConfig schema = c.getSchemaConfig();
+        if (schema == null) {
+            c.writeErrMessage(ErrorCode.ER_BAD_DB_ERROR, "Unknown database '" + c.getSchema() + "'");
+            return false;
+        }
+
+        TDataSource ds = schema.getDataSource();
+        if (!ds.isInited()) {
+            try {
+                ds.init();
+            } catch (Throwable e) {
+                c.handleError(ErrorCode.ERR_HANDLE_DATA, e);
+                return false;
+            }
+        }
+
+        OptimizerContext.setContext(ds.getConfigHolder().getOptimizerContext());
+        List<List<Map<String, Object>>> results = SyncManagerHelper.sync(new ShowConnectionSyncAction(
+            c.getUser(), c.getSchema()), c.getSchema());
+        for (List<Map<String, Object>> rs : results) {
+            if (rs == null) {
+                continue;
+            }
+
+            for (Map<String, Object> conn : rs) {
+                RowDataPacket row = new RowDataPacket(FIELD_COUNT);
+                row.add(StringUtil.encode(DataTypes.StringType.convertFrom(conn.get("ID")), charset));
+                row.add(StringUtil.encode(DataTypes.StringType.convertFrom(conn.get("HOST")), charset));
+                row.add(IntegerUtil.toBytes(DataTypes.IntegerType.convertFrom(conn.get("PORT"))));
+                row.add(IntegerUtil.toBytes(DataTypes.IntegerType.convertFrom(conn.get("LOCAL_PORT"))));
+                row.add(StringUtil.encode(DataTypes.StringType.convertFrom(conn.get("SCHEMA")), charset));
+                row.add(StringUtil.encode(DataTypes.StringType.convertFrom(conn.get("CHARSET")), charset));
+                row.add(LongUtil.toBytes(DataTypes.LongType.convertFrom(conn.get("NET_IN"))));
+                row.add(LongUtil.toBytes(DataTypes.LongType.convertFrom(conn.get("NET_OUT"))));
+                row.add(LongUtil.toBytes(DataTypes.LongType.convertFrom(conn.get("ALIVE_TIME(S)"))));
+                row.add(LongUtil.toBytes(DataTypes.LongType.convertFrom(conn.get("LAST_ACTIVE"))));
+                row.add(IntegerUtil.toBytes(DataTypes.IntegerType.convertFrom(conn.get("CHANNELS"))));
+                row.add(IntegerUtil.toBytes(DataTypes.IntegerType.convertFrom(conn.get("TRX"))));
+                row.add(IntegerUtil.toBytes(DataTypes.IntegerType.convertFrom(conn.get("NEED_RECONNECT"))));
+                row.add(StringUtil.encode(DataTypes.StringType.convertFrom(conn.get("PARTITION_HINT")), charset));
+                row.packetId = ++packetId;
+                proxy = row.write(proxy);
+
+            }
+        }
+        // write last eof
+        EOFPacket lastEof = new EOFPacket();
+        lastEof.packetId = ++packetId;
+        if (hasMore) {
+            lastEof.status |= MySQLPacket.SERVER_MORE_RESULTS_EXISTS;
+        }
+        proxy = lastEof.write(proxy);
+
+        // write buffer
+        proxy.packetEnd();
+        return true;
+    }
+
+}

--- a/polardbx-test/src/test/java/com/alibaba/polardbx/qatest/dml/auto/basecrud/SessionHintTest.java
+++ b/polardbx-test/src/test/java/com/alibaba/polardbx/qatest/dml/auto/basecrud/SessionHintTest.java
@@ -2,28 +2,46 @@ package com.alibaba.polardbx.qatest.dml.auto.basecrud;
 
 import com.alibaba.polardbx.common.utils.Assert;
 import com.alibaba.polardbx.qatest.BaseTestCase;
+import com.alibaba.polardbx.qatest.validator.DataOperator;
+import com.alibaba.polardbx.qatest.validator.DataValidator;
 import com.google.common.collect.Maps;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 
 /**
+ * Partition Hint test cases
+ *
  * @author fangwu
  */
 public class SessionHintTest extends BaseTestCase {
     private static final Log log = LogFactory.getLog("ROOT");
+    private static final String TBL_NAME = "session_hint_test";
+    private static final String CREATE_TBL = "CREATE TABLE if not exists `session_hint_test` (\n"
+        + "    `pk` bigint(11) NOT NULL,\n"
+        + "    `integer_test` int(11) DEFAULT NULL,\n"
+        + "    PRIMARY KEY (`pk`)\n"
+        + ") ENGINE = InnoDB DEFAULT CHARSET = utf8";
 
     /**
      * test if push hint working
-     * set partition_name=xxx;
+     * set partition_hint=xxx;
      * trace select * from xxx;
-     * show trace && check if partition_name work
+     * show trace && check if partition_hint work
      */
     @Test
     public void testSessionHintWithShardingTable() throws SQLException {
@@ -31,7 +49,7 @@ public class SessionHintTest extends BaseTestCase {
         try {
             c = getPolardbxConnection();
             c.createStatement().execute("use drds_polarx1_qatest_app");
-            c.createStatement().execute("set partition_name=DRDS_POLARX1_QATEST_APP_000001_GROUP");
+            c.createStatement().execute("set partition_hint=DRDS_POLARX1_QATEST_APP_000001_GROUP");
             c.createStatement().execute("trace select * from select_base_three_multi_db_one_tb");
             ResultSet rs = c.createStatement().executeQuery("show trace");
 
@@ -40,16 +58,16 @@ public class SessionHintTest extends BaseTestCase {
                 Assert.assertTrue(groupName.equalsIgnoreCase("DRDS_POLARX1_QATEST_APP_000001_GROUP"));
             }
         } finally {
-            Objects.requireNonNull(c).createStatement().execute("set partition_name=''");
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
             log.info("session hint test end");
         }
     }
 
     /**
      * test if push hint working
-     * set partition_name=xxx;
+     * set partition_hint=xxx;
      * trace select * from xxx;
-     * show trace && check if partition_name work
+     * show trace && check if partition_hint work
      */
     @Test
     public void testSessionHintWithAutoTable() throws SQLException {
@@ -64,7 +82,7 @@ public class SessionHintTest extends BaseTestCase {
             Map<String, String> partGroupMap = Maps.newHashMap();
             while (topologyRs.next()) {
                 String groupName = topologyRs.getString("GROUP_NAME");
-                String partName = topologyRs.getString("PARTITION_NAME");
+                String partName = topologyRs.getString("partition_name");
                 partGroupMap.put(partName, groupName);
             }
 
@@ -72,15 +90,9 @@ public class SessionHintTest extends BaseTestCase {
             for (Map.Entry<String, String> entry : partGroupMap.entrySet()) {
                 String partName = entry.getKey();
                 String checkGroupName = entry.getValue();
-                c.createStatement().execute("set partition_name=" + partName);
-                c.createStatement().execute("trace select * from " + tableName);
-                ResultSet rs = c.createStatement().executeQuery("show trace");
-
-                while (rs.next()) {
-                    String groupName = rs.getString("GROUP_NAME");
-                    Assert.assertTrue(groupName.equalsIgnoreCase(checkGroupName));
-                }
-                rs.close();
+                checkHintWork(c, TBL_NAME);
+                c.createStatement().execute("set partition_hint=" + partName);
+                ResultSet rs;
                 String joinSql =
                     "trace select * from " + tableName + " a join select_base_two_multi_db_multi_tb b on a.pk=b.pk";
                 c.createStatement().executeQuery(joinSql);
@@ -92,23 +104,42 @@ public class SessionHintTest extends BaseTestCase {
                 }
             }
 
+            // broadcast table
             try {
-                String errorSql =
+                String sqlWithBroadcast =
                     "trace select * from select_base_two_multi_db_one_tb a join select_base_four_broadcast b on a.pk=b.pk;";
-                c.createStatement().execute("set partition_name=p3");
-                c.createStatement().executeQuery(errorSql);
-                Assert.fail(" error sql should product error msg");
+                c.createStatement().execute("set partition_hint=p3");
+                c.createStatement().executeQuery(sqlWithBroadcast);
             } catch (SQLException sqlException) {
                 sqlException.printStackTrace();
                 log.info(sqlException.getMessage());
-                Assert.assertTrue(
-                    sqlException.getMessage().contains("Unsupported to use direct HINT "));
+                Assert.fail(
+                    "partition hint should ignore broadcast table partition and replace its physical table name");
+            }
+
+            // partition hint won't infect broadcast table
+            try {
+                String sqlWithBroadcast = "trace select * from select_base_four_broadcast b";
+                c.createStatement().execute("set partition_hint=p3333");
+                c.createStatement().executeQuery(sqlWithBroadcast);
+                ResultSet rs = c.createStatement().executeQuery("show trace");
+                String groupName;
+                while (rs.next()) {
+                    groupName = rs.getString("GROUP_NAME");
+                    Assert.assertTrue(groupName.equalsIgnoreCase("DRDS_POLARX1_PART_QATEST_APP_P00000_GROUP"));
+                }
+                rs.close();
+            } catch (SQLException sqlException) {
+                sqlException.printStackTrace();
+                log.info(sqlException.getMessage());
+                Assert.fail(
+                    "partition hint should ignore broadcast table partition and replace its physical table name");
             }
 
             try {
                 String errorSql =
                     "trace select * from select_base_two_multi_db_one_tb a";
-                c.createStatement().execute("set partition_name=p1111");
+                c.createStatement().execute("set partition_hint=p1111");
                 c.createStatement().executeQuery(errorSql);
                 Assert.fail(" error sql should product error msg");
             } catch (SQLException sqlException) {
@@ -118,7 +149,7 @@ public class SessionHintTest extends BaseTestCase {
                     sqlException.getMessage().contains("Unsupported to use direct HINT "));
             }
         } finally {
-            Objects.requireNonNull(c).createStatement().execute("set partition_name=''");
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
             log.info("session hint test end");
         }
     }
@@ -128,7 +159,7 @@ public class SessionHintTest extends BaseTestCase {
         Connection c1 = null;
         Connection c2 = null;
         Connection c3 = null;
-        ResultSet rs = null;
+        ResultSet rs;
         try {
             c1 = getPolardbxConnection();
             c2 = getPolardbxConnection();
@@ -181,10 +212,928 @@ public class SessionHintTest extends BaseTestCase {
             rs.close();
 
         } finally {
-            Objects.requireNonNull(c1).createStatement().execute("set partition_name=''");
+            Objects.requireNonNull(c1).createStatement().execute("set partition_hint=''");
             Objects.requireNonNull(c1).close();
             Objects.requireNonNull(c2).close();
             Objects.requireNonNull(c3).close();
+            log.info("session hint test end");
+        }
+    }
+
+    @Test
+    public void testSessionHintWithDdl() throws SQLException {
+        Connection connWithHint = null;
+        Connection connWithoutHint = null;
+        Random r = new Random();
+        String tblName = "session_hint_ddl_test_tb_" + r.nextInt(10000);
+        try {
+            connWithoutHint = getPolardbxConnection();
+            connWithoutHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+            connWithHint = getPolardbxConnection();
+            connWithHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+
+            connWithHint.createStatement().execute("set partition_hint=p3");
+
+            // test hint working
+            checkHintWork(connWithHint, "select_base_three_multi_db_one_tb");
+
+            // test create logical table
+            connWithHint.createStatement().execute("CREATE TABLE " + tblName + "  (\n"
+                + "\t`id` bigint(20) NOT NULL,\n"
+                + "\t`ubigint_id` bigint(20) UNSIGNED DEFAULT NULL\n"
+                + ") ENGINE = InnoDB DEFAULT CHARSET = utf8");
+
+            // get partition name and group name
+            ResultSet rs = connWithHint.createStatement().executeQuery("show topology from " + tblName);
+            rs.next();
+            String groupName = rs.getString("GROUP_NAME");
+            String partitionName = rs.getString("PARTITION_NAME");
+
+            Assert.assertTrue(StringUtils.isNotEmpty(partitionName) && StringUtils.isNotEmpty(groupName));
+            rs.close();
+
+            // check session hint working for new table
+            connWithHint.createStatement().execute("set partition_hint= " + partitionName);
+            connWithHint.createStatement().execute("trace select * from " + tblName);
+            rs = connWithHint.createStatement().executeQuery("show trace");
+            while (rs.next()) {
+                String groupNameTmp = rs.getString("GROUP_NAME");
+                Assert.assertTrue(groupNameTmp.equalsIgnoreCase(groupName));
+            }
+            rs.close();
+        } finally {
+            Objects.requireNonNull(connWithHint).createStatement().execute("drop table if exists " + tblName);
+            Objects.requireNonNull(connWithHint).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(connWithHint).close();
+            Objects.requireNonNull(connWithoutHint).close();
+            log.info("session hint test end");
+        }
+    }
+
+    @Test
+    public void testSessionHintWithInformationSchema() throws SQLException {
+        Connection connWithHint = null;
+        Connection connWithoutHint = null;
+        try {
+            connWithoutHint = getPolardbxConnection();
+            connWithoutHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+            connWithHint = getPolardbxConnection();
+            connWithHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+
+            connWithHint.createStatement().execute("set partition_hint=p3");
+
+            checkHintWork(connWithHint, TBL_NAME);
+
+            // test normal hint won't interrupt partition hint
+            DataValidator.selectContentSameAssert("select * from information_schema.views", null, connWithHint,
+                connWithoutHint, true);
+            DataValidator.selectContentSameAssert("select * from information_schema.tables", null, connWithHint,
+                connWithoutHint);
+            DataValidator.selectContentSameAssert(
+                "select MODULE_NAME, host, schedule_jobs, views from information_schema.module", null, connWithHint,
+                connWithoutHint);
+            DataValidator.selectContentSameAssert("select * from information_schema.column_statistics", null,
+                connWithHint, connWithoutHint);
+
+        } finally {
+            Objects.requireNonNull(connWithHint).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(connWithHint).close();
+            Objects.requireNonNull(connWithoutHint).close();
+            log.info("session hint test end");
+        }
+    }
+
+    private void checkHintWork(Connection conn, String tblName) throws SQLException {
+        // prepare table
+        conn.createStatement().execute(CREATE_TBL);
+
+        // get group name and partition name
+        ResultSet rs = conn.createStatement().executeQuery("show topology from  " + tblName);
+
+        String groupName = null;
+        String partitionName = null;
+        while (rs.next()) {
+            groupName = rs.getString("GROUP_NAME");
+            partitionName = rs.getString("PARTITION_NAME");
+            break;
+        }
+        rs.close();
+        Assert.assertTrue(groupName != null && partitionName != null);
+
+        // test partition hint working
+        conn.createStatement().execute("set partition_hint=" + partitionName);
+        conn.createStatement().execute("trace select * from " + tblName);
+        rs = conn.createStatement().executeQuery("show trace");
+
+        while (rs.next()) {
+            String groupNameTmp = rs.getString("GROUP_NAME");
+            Assert.assertTrue(groupNameTmp.equalsIgnoreCase(groupName));
+        }
+        rs.close();
+        conn.createStatement().execute("set partition_hint=''");
+    }
+
+    @Test
+    public void testSessionHintWithShowCommandAndDal() throws SQLException {
+        Connection connWithHint = null;
+        Connection connWithoutHint = null;
+        try {
+            connWithoutHint = getPolardbxConnection();
+            connWithoutHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+            connWithHint = getPolardbxConnection();
+            connWithHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+
+            connWithHint.createStatement().execute("set partition_hint=p3");
+
+            // test hint working
+            checkHintWork(connWithHint, TBL_NAME);
+
+            // test show command
+            DataValidator.selectContentSameAssert("show tables", null, connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show full tables", null, connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show ddl", null, connWithHint, connWithoutHint, true);
+            DataValidator.selectContentSameAssert("show full ddl", null, connWithHint, connWithoutHint, true);
+            DataValidator.selectContentSameAssert("show ddl status", null, connWithHint, connWithoutHint, true);
+            DataValidator.selectContentSameAssert("show ddl result", null, connWithHint, connWithoutHint, true);
+            DataValidator.selectContentSameAssert("show rule", null, connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show rule from select_base_three_multi_db_multi_tb", null,
+                connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show full rule from select_base_three_multi_db_multi_tb", null,
+                connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show topology from select_base_three_multi_db_multi_tb", null,
+                connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show partitions from select_base_three_multi_db_multi_tb", null,
+                connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show broadcasts", null, connWithHint, connWithoutHint);
+            // show datasources cannot make sure POOLING_COUNT same
+            DataValidator.selectConutAssert("show datasources", null, connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show node", null, connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show slow", null, connWithHint, connWithoutHint, true);
+            DataValidator.selectConutAssert("show physical_slow", null, connWithHint, connWithoutHint);
+            DataOperator.executeOnMysqlAndTddl(connWithHint, connWithoutHint, "clear slow", null);
+            DataValidator.selectContentSameAssert(
+                "explain optimizer select * from select_base_three_multi_db_multi_tb order by pk", null, connWithHint,
+                connWithoutHint);
+
+            // explain advisor/json_plan might cause different result in different cn node
+            connWithHint.createStatement().executeQuery(
+                "explain advisor select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk");
+            connWithoutHint.createStatement().executeQuery(
+                "explain advisor select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk");
+
+            connWithHint.createStatement().execute("analyze table select_base_three_multi_db_multi_tb");
+            DataValidator.selectContentSameAssert(
+                "explain STATISTICS select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk",
+                null, connWithHint, connWithoutHint);
+
+            connWithHint.createStatement().executeQuery(
+                "explain JSON_PLAN select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk");
+            connWithoutHint.createStatement().executeQuery(
+                "explain JSON_PLAN select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk");
+
+            connWithHint.createStatement().executeQuery(
+                "explain EXECUTE select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk");
+            connWithoutHint.createStatement().executeQuery(
+                "explain EXECUTE select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk");
+
+            DataValidator.selectContentSameAssert(
+                "explain SHARDING select * from select_base_three_multi_db_multi_tb where varchar_test='12' order by pk",
+                null, connWithHint, connWithoutHint);
+            DataValidator.selectContentSameAssert("show sequences", null, connWithHint, connWithoutHint);
+            connWithHint.createStatement().execute("create sequence session_hint_test_seq start with 100");
+            connWithHint.createStatement().execute("alter sequence session_hint_test_seq start with 99");
+            connWithHint.createStatement().execute("drop sequence session_hint_test_seq");
+
+            connWithHint.createStatement().execute("clear ccl_rules");
+            connWithHint.createStatement().execute("clear ccl_triggers");
+
+            // thread running might be different
+            connWithHint.createStatement().execute("show db status");
+            connWithHint.createStatement().execute("show full db status");
+
+            DataValidator.selectContentSameAssert("show ds", null, connWithHint, connWithoutHint);
+            connWithHint.createStatement().execute("show connection");
+            DataValidator.selectContentSameAssert("show trans", null, connWithHint, connWithoutHint, true);
+            DataValidator.selectContentSameAssert("show full trans", null, connWithHint, connWithoutHint, true);
+            DataValidator.selectContentSameAssert("show ccl_rules", null, connWithHint, connWithoutHint, true);
+
+            // test check table
+            DataValidator.selectContentSameAssert("check table select_base_four_multi_db_multi_tb;", null, connWithHint,
+                connWithoutHint, true);
+        } finally {
+            Objects.requireNonNull(connWithHint).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(connWithHint).close();
+            Objects.requireNonNull(connWithoutHint).close();
+            log.info("session hint test end");
+        }
+    }
+
+    @Test
+    public void testSessionHintWithDirectHint() throws SQLException {
+        Connection connWithHint = null;
+        try {
+            connWithHint = getPolardbxConnection();
+            connWithHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+
+            connWithHint.createStatement().execute("set partition_hint=p3");
+
+            // test partition hint working
+            checkHintWork(connWithHint, TBL_NAME);
+            ResultSet rs;
+
+            // test normal hint won't interrupt partition hint
+            // get group name and partition name
+            rs = connWithHint.createStatement().executeQuery("show topology from  " + TBL_NAME);
+
+            String groupName = null;
+            String partitionName = null;
+            String tableName = null;
+            while (rs.next()) {
+                groupName = rs.getString("GROUP_NAME");
+                partitionName = rs.getString("PARTITION_NAME");
+                tableName = rs.getString("TABLE_NAME");
+                break;
+            }
+            rs.close();
+            Assert.assertTrue(groupName != null && partitionName != null);
+
+            // test partition hint working
+            connWithHint.createStatement().execute("set partition_hint=" + partitionName);
+            connWithHint.createStatement()
+                .execute("trace /*TDDL:test_hint=true*/ select * from select_base_three_multi_db_one_tb");
+            rs = connWithHint.createStatement().executeQuery("show trace");
+
+            while (rs.next()) {
+                String groupNameTmp = rs.getString("GROUP_NAME");
+                Assert.assertTrue(groupNameTmp.equalsIgnoreCase(groupName));
+            }
+            rs.close();
+
+            // test node hint would interrupt partition hint
+            Assert.assertTrue(groupName != null);
+            Assert.assertTrue(tableName != null);
+            connWithHint.createStatement()
+                .execute("trace /*TDDL:node=" + groupName + "*/ select * from " + tableName);
+
+        } finally {
+            Objects.requireNonNull(connWithHint).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(connWithHint).close();
+            log.info("session hint test end");
+        }
+    }
+
+    @Ignore
+    public void testSessionHintWithFlashBack() throws SQLException, InterruptedException {
+        Connection connWithHint = null;
+        try {
+            connWithHint = getPolardbxConnection();
+            connWithHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+
+            connWithHint.createStatement().execute("set partition_hint=p3");
+            connWithHint.createStatement().execute("set global ENABLE_FORBID_PUSH_DML_WITH_HINT=false");
+            Thread.sleep(2000);
+            // test partition hint working
+            checkHintWork(connWithHint, TBL_NAME);
+            ResultSet rs;
+
+            // clear data
+            connWithHint.createStatement().execute("truncate table update_delete_base_autonic_multi_db_multi_tb");
+
+            // test insert into partition table
+            Calendar current = Calendar.getInstance();
+            SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            connWithHint.setAutoCommit(false);
+            connWithHint.createStatement()
+                .execute(
+                    "insert into update_delete_base_autonic_multi_db_multi_tb(varchar_test, timestamp_test) values('session hint test value', now())");
+            connWithHint.commit();
+            rs = connWithHint.createStatement().executeQuery(
+                "select * from update_delete_base_autonic_multi_db_multi_tb as of timestamp '" + f.format(
+                    current.getTime()) + "' where varchar_test='session hint test value'");
+            System.out.println(
+                "select * from update_delete_base_autonic_multi_db_multi_tb as of timestamp '" + f.format(
+                    current.getTime()) + "' where varchar_test='session hint test value'");
+            while (rs.next()) {
+                Assert.fail("should not query any value by flashback");
+            }
+            rs.close();
+        } finally {
+            Objects.requireNonNull(connWithHint).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(connWithHint).close();
+            log.info("session hint test end");
+        }
+    }
+
+    @Test
+    public void testSessionHintForbiddenByConfig() throws SQLException, InterruptedException {
+        Connection connWithHint = null;
+        try {
+            connWithHint = getPolardbxConnection();
+            connWithHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+
+            connWithHint.createStatement().execute("set partition_hint=p3");
+            connWithHint.createStatement().execute("set global ENABLE_FORBID_PUSH_DML_WITH_HINT=true");
+            Thread.sleep(2000);
+            connWithHint.setAutoCommit(false);
+
+            // test partition hint working
+            checkHintWork(connWithHint, TBL_NAME);
+            connWithHint.createStatement().execute("set partition_hint=p3");
+            try {
+                connWithHint.createStatement()
+                    .execute(
+                        "insert into update_delete_base_autonic_multi_db_multi_tb(varchar_test, timestamp_test) values('session hint test value', now())");
+                Assert.fail(" dml should be forbidden by ENABLE_FORBID_PUSH_DML_WITH_HINT=true");
+            } catch (SQLException e) {
+                if (!e.getMessage().contains("Unsupported to push physical dml by hint ")) {
+                    throw e;
+                }
+            }
+
+            try {
+                connWithHint.createStatement()
+                    .execute(
+                        "update update_delete_base_autonic_multi_db_multi_tb set varchar_test='session hint test value'");
+                Assert.fail(" dml should be forbidden by ENABLE_FORBID_PUSH_DML_WITH_HINT=true");
+            } catch (SQLException e) {
+                if (!e.getMessage().contains("Unsupported to push physical dml by hint ")) {
+                    throw e;
+                }
+            }
+
+            try {
+                connWithHint.createStatement()
+                    .execute(
+                        "insert into update_delete_base_autonic_multi_db_multi_tb select * from update_delete_base_autonic_string_multi_db_multi_tb");
+                Assert.fail(" dml should be forbidden by ENABLE_FORBID_PUSH_DML_WITH_HINT=true");
+            } catch (SQLException e) {
+                if (!e.getMessage().contains("Unsupported to push physical dml by hint ")) {
+                    throw e;
+                }
+            }
+        } finally {
+            Objects.requireNonNull(connWithHint).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(connWithHint).close();
+            log.info("session hint test end");
+        }
+    }
+
+    @Test
+    public void testSessionHintWithDML() throws SQLException, InterruptedException {
+        Connection connWithHint = null;
+        try {
+            connWithHint = getPolardbxConnection();
+            connWithHint.createStatement().execute("use drds_polarx1_part_qatest_app");
+
+            connWithHint.createStatement().execute("set partition_hint=p3");
+            connWithHint.createStatement().execute("set global ENABLE_FORBID_PUSH_DML_WITH_HINT=false");
+            Thread.sleep(2000);
+
+            // test partition hint working
+            checkHintWork(connWithHint, TBL_NAME);
+
+            connWithHint.createStatement()
+                .execute(
+                    "insert into update_delete_base_autonic_multi_db_multi_tb(varchar_test, timestamp_test) values('session hint test value', now())");
+
+            connWithHint.createStatement()
+                .execute(
+                    "update update_delete_base_autonic_multi_db_multi_tb set varchar_test='session hint test value111'");
+            connWithHint.createStatement()
+                .execute("truncate table update_delete_base_autonic_string_multi_db_multi_tb");
+            connWithHint.createStatement()
+                .execute(
+                    "insert into update_delete_base_autonic_string_multi_db_multi_tb  select * from update_delete_base_autonic_multi_db_multi_tb");
+        } finally {
+            Objects.requireNonNull(connWithHint).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(connWithHint).close();
+            log.info("session hint test end");
+        }
+    }
+
+    /**
+     * test if push hint working on multi table
+     * set partition_hint=xxx;
+     * trace select * from xxx;
+     * show trace && check if partition_hint work
+     */
+    @Test
+    public void testSessionHintWithShardingMultiTable() throws SQLException {
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_qatest_app");
+            c.createStatement().execute("set partition_hint='DRDS_POLARX1_QATEST_APP_000001_GROUP:00'");
+            c.createStatement().execute("trace select * from select_base_three_multi_db_multi_tb");
+            ResultSet rs = c.createStatement().executeQuery("show trace");
+
+            while (rs.next()) {
+                String groupName = rs.getString("GROUP_NAME");
+                Assert.assertTrue(groupName.equalsIgnoreCase("DRDS_POLARX1_QATEST_APP_000001_GROUP"));
+            }
+
+            c.createStatement().execute("set partition_hint='DRDS_POLARX1_QATEST_APP_000001_GROUP:1'");
+            c.createStatement().execute("trace select * from select_base_three_multi_db_multi_tb");
+            rs = c.createStatement().executeQuery("show trace");
+
+            while (rs.next()) {
+                String groupName = rs.getString("GROUP_NAME");
+                Assert.assertTrue(groupName.equalsIgnoreCase("DRDS_POLARX1_QATEST_APP_000001_GROUP"));
+            }
+
+            c.createStatement().execute("set partition_hint='DRDS_POLARX1_QATEST_APP_000001_GROUP:4'");
+            try {
+                c.createStatement().execute("trace select * from select_base_three_multi_db_multi_tb");
+            } catch (SQLException e) {
+                Assert.assertTrue(e.getMessage()
+                    .contains("table index overflow in target group from direct HINT for sharding table"));
+            }
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+    }
+
+    @Test
+    public void testSessionHintWithJoin() throws SQLException {
+        // drds table with different sharding table num, report error
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_qatest_app");
+            c.createStatement().execute("set partition_hint='DRDS_POLARX1_QATEST_APP_000001_GROUP:00'");
+
+            try {
+                c.createStatement().execute(
+                    "select * from select_base_three_multi_db_multi_tb a join select_base_three_multi_db_one_tb b on a.pk=b.pk");
+                Assert.fail("should report error");
+            } catch (SQLException e) {
+                Assert.assertTrue(e.getMessage()
+                    .contains("different sharding table num in partition hint mode"));
+            }
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+
+        // auto table in different table group, report error
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_part_qatest_app");
+            c.createStatement().execute("set partition_hint='p1'");
+
+            // create table group
+            c.createStatement().execute("create tablegroup if not exists partition_hint_test_tg1");
+            c.createStatement().execute("create tablegroup if not exists partition_hint_test_tg2");
+
+            // create table into table group partition_test_tg1
+            c.createStatement().execute("CREATE TABLE if not exists `partition_hint_test_tbl1` (\n"
+                + "        `a` datetime NOT NULL\n"
+                + ") ENGINE = InnoDB DEFAULT CHARSET = utf8mb4  \n"
+                + "TABLEGROUP=partition_hint_test_tg1\n"
+                + "PARTITION BY RANGE(YEAR(a))\n"
+                + "(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,\n"
+                + " PARTITION p1 VALUES LESS THAN (2000) ENGINE = InnoDB,\n"
+                + " PARTITION p2 VALUES LESS THAN (2010) ENGINE = InnoDB,\n"
+                + " PARTITION p3 VALUES LESS THAN (2020) ENGINE = InnoDB);");
+
+            c.createStatement().execute("CREATE TABLE if not exists `partition_hint_test_tbl2` (\n"
+                + "        `a` datetime NOT NULL\n"
+                + ") ENGINE = InnoDB DEFAULT CHARSET = utf8mb4  \n"
+                + "TABLEGROUP=partition_hint_test_tg2\n"
+                + "PARTITION BY RANGE(YEAR(a))\n"
+                + "(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,\n"
+                + " PARTITION p1 VALUES LESS THAN (2000) ENGINE = InnoDB,\n"
+                + " PARTITION p2 VALUES LESS THAN (2010) ENGINE = InnoDB,\n"
+                + " PARTITION p3 VALUES LESS THAN (2020) ENGINE = InnoDB);");
+
+            // test different table group error report
+            try {
+                c.createStatement()
+                    .execute("select * from partition_hint_test_tbl1 a join partition_hint_test_tbl2 b on a.a=b.a");
+                Assert.fail("should report error");
+            } catch (SQLException e) {
+                Assert.assertTrue(e.getMessage()
+                    .contains("different table group in partition hint mode"));
+            }
+
+            // change table group to same one:partition_hint_test_tbl1
+            c.createStatement().execute("ALTER TABLE partition_hint_test_tbl2 set TABLEGROUP=partition_hint_test_tg1;");
+
+            // test if same table group work
+            c.createStatement()
+                .execute("select * from partition_hint_test_tbl1 a join partition_hint_test_tbl2 b on a.a=b.a");
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(c).createStatement().execute("drop table if exists partition_hint_test_tbl1");
+            Objects.requireNonNull(c).createStatement().execute("drop table if exists partition_hint_test_tbl2");
+            Objects.requireNonNull(c).createStatement().execute("drop tablegroup if exists partition_hint_test_tg1");
+            Objects.requireNonNull(c).createStatement().execute("drop tablegroup if exists partition_hint_test_tg2");
+            log.info("session hint test end");
+        }
+
+        // test auto table join with broadcast table
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_part_qatest_app");
+            c.createStatement().execute("set partition_hint='p1'");
+
+            // create table group
+            c.createStatement().execute("create tablegroup if not exists partition_hint_test_tg1");
+
+            // create table into table group partition_test_tg1
+            c.createStatement().execute("CREATE TABLE if not exists `partition_hint_test_tbl1` (\n"
+                + "        `a` datetime NOT NULL\n"
+                + ") ENGINE = InnoDB DEFAULT CHARSET = utf8mb4  \n"
+                + "TABLEGROUP=partition_hint_test_tg1\n"
+                + "PARTITION BY RANGE(YEAR(a))\n"
+                + "(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,\n"
+                + " PARTITION p1 VALUES LESS THAN (2000) ENGINE = InnoDB,\n"
+                + " PARTITION p2 VALUES LESS THAN (2010) ENGINE = InnoDB,\n"
+                + " PARTITION p3 VALUES LESS THAN (2020) ENGINE = InnoDB);");
+
+            c.createStatement().execute("CREATE TABLE if not exists `partition_hint_test_tbl2` (\n"
+                + "        `a` datetime NOT NULL\n"
+                + ") ENGINE = InnoDB DEFAULT CHARSET = utf8mb4  \n"
+                + "BROADCAST");
+
+            // test if table with broadcast table work
+            c.createStatement()
+                .execute("select * from partition_hint_test_tbl1 a join partition_hint_test_tbl2 b on a.a=b.a");
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(c).createStatement().execute("drop table if exists partition_hint_test_tbl1");
+            Objects.requireNonNull(c).createStatement().execute("drop table if exists partition_hint_test_tbl2");
+            Objects.requireNonNull(c).createStatement().execute("drop tablegroup if exists partition_hint_test_tg1");
+            log.info("session hint test end");
+        }
+    }
+
+    @Test
+    public void testSessionHintCrossSchema() throws SQLException {
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_qatest_app");
+            c.createStatement().execute("set partition_hint='DRDS_POLARX1_QATEST_APP_000001_GROUP:00'");
+
+            c.createStatement().execute("select * from drds_polarx1_qatest_app.select_base_three_multi_db_multi_tb");
+
+            try {
+                c.createStatement()
+                    .execute("select * from drds_polarx1_part_qatest_app.select_base_three_multi_db_multi_tb");
+                Assert.fail("should report error");
+            } catch (SQLException e) {
+                log.info(e.getMessage());
+                Assert.assertTrue(
+                    e.getMessage().contains("partition hint visit table crossing schema"));
+            }
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+    }
+
+    /**
+     * partition hint with physical table name should cause table not exists error
+     * this condition should use direct node
+     */
+    @Test
+    public void testSessionHintWithPhysicalTableName() throws SQLException {
+        Connection c = null;
+
+        // drds table
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_qatest_app");
+            c.createStatement().execute("set partition_hint='DRDS_POLARX1_QATEST_APP_000001_GROUP:00'");
+
+            /*
+             * expected table topology
+             * |    0 | DRDS_POLARX1_QATEST_APP_000000_GROUP | select_base_three_multi_db_multi_tb_i9JV_00 | -              |
+             * |    1 | DRDS_POLARX1_QATEST_APP_000000_GROUP | select_base_three_multi_db_multi_tb_i9JV_01 | -              |
+             * |    2 | DRDS_POLARX1_QATEST_APP_000000_GROUP | select_base_three_multi_db_multi_tb_i9JV_02 | -              |
+             * |    3 | DRDS_POLARX1_QATEST_APP_000000_GROUP | select_base_three_multi_db_multi_tb_i9JV_03 | -              |
+             * |    4 | DRDS_POLARX1_QATEST_APP_000001_GROUP | select_base_three_multi_db_multi_tb_i9JV_04 | -              |
+             * |    5 | DRDS_POLARX1_QATEST_APP_000001_GROUP | select_base_three_multi_db_multi_tb_i9JV_05 | -              |
+             * |    6 | DRDS_POLARX1_QATEST_APP_000001_GROUP | select_base_three_multi_db_multi_tb_i9JV_06 | -              |
+             * |    7 | DRDS_POLARX1_QATEST_APP_000001_GROUP | select_base_three_multi_db_multi_tb_i9JV_07 | -              |
+             * ... ...
+             */
+            c.createStatement().execute("select * from drds_polarx1_qatest_app.select_base_three_multi_db_multi_tb");
+
+            try {
+                c.createStatement()
+                    .execute(
+                        "select * from select_base_three_multi_db_multi_tb_i9JV_02 a join select_base_three_multi_db_one_tb b on a.pk=b.pk;");
+                Assert.fail("should report error");
+            } catch (SQLException e) {
+                log.info(e.getMessage());
+                Assert.assertTrue(e.getMessage().contains("[ERR_TABLE_NOT_EXIST]"));
+            }
+            try {
+                c.createStatement()
+                    .execute(
+                        "select * from select_base_three_multi_db_multi_tb_i9JV_06 a join select_base_three_multi_db_one_tb b on a.pk=b.pk;");
+            } catch (SQLException e) {
+                log.info(e.getMessage());
+                Assert.assertTrue(e.getMessage().contains("[ERR_TABLE_NOT_EXIST]"));
+            }
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+
+        // auto table
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_part_qatest_app");
+            c.createStatement().execute("set partition_hint=p2");
+
+            /*
+             * expected topology
+             * |    0 | DRDS_POLARX1_PART_QATEST_APP_P00000_GROUP | select_base_three_multi_db_multi_tb_MvY5_00001 | p2
+             * |    1 | DRDS_POLARX1_PART_QATEST_APP_P00001_GROUP | select_base_three_multi_db_multi_tb_MvY5_00000 | p1
+             * |    2 | DRDS_POLARX1_PART_QATEST_APP_P00001_GROUP | select_base_three_multi_db_multi_tb_MvY5_00002 | p3
+             * ... ...
+             */
+            c.createStatement()
+                .execute("select * from drds_polarx1_part_qatest_app.select_base_three_multi_db_multi_tb");
+
+            try {
+                c.createStatement()
+                    .execute(
+                        "select * from select_base_three_multi_db_multi_tb_MvY5_00002 a join select_base_three_multi_db_one_tb b on a.pk=b.pk;");
+                Assert.fail("should report error");
+            } catch (SQLException e) {
+                log.info(e.getMessage());
+                Assert.assertTrue(e.getMessage().contains("[ERR_TABLE_NOT_EXIST]"));
+            }
+            try {
+                c.createStatement()
+                    .execute(
+                        "select * from select_base_three_multi_db_multi_tb_MvY5_00001 a join select_base_three_multi_db_one_tb b on a.pk=b.pk;");
+
+            } catch (SQLException e) {
+                log.info(e.getMessage());
+                Assert.assertTrue(e.getMessage().contains("[ERR_TABLE_NOT_EXIST]"));
+            }
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+    }
+
+    /**
+     * show full connection would output partition hint info.
+     */
+    @Test
+    public void testShowFullConnection() throws SQLException {
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("use drds_polarx1_qatest_app");
+            c.createStatement().execute("set partition_hint='DRDS_POLARX1_QATEST_APP_000001_GROUP:00'");
+
+            ResultSet rs = c.createStatement().executeQuery("show full connection");
+
+            boolean found = false;
+            while (rs.next()) {
+                String hint = rs.getString("PARTITION_HINT");
+                if ("DRDS_POLARX1_QATEST_APP_000001_GROUP:00".equalsIgnoreCase(hint)) {
+                    found = true;
+                }
+            }
+            Assert.assertTrue(found);
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+    }
+
+    /**
+     * partition hint with dml on table with gsi should report error.
+     */
+    @Test
+    public void testDmlWithAutoGsi() throws SQLException {
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("drop database if exists partition_hint_test");
+            c.createStatement().execute("create database if not exists partition_hint_test mode=auto");
+            c.createStatement().execute("use partition_hint_test");
+            Random r = new Random();
+            String tblName = "session_hint_dml_test_tb_order_" + r.nextInt(10000);
+            c.createStatement().execute(
+                "CREATE PARTITION TABLE " + tblName + "(\n"
+                    + "    `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"
+                    + "    `bid` int(11) DEFAULT NULL,\n"
+                    + "    `name` varchar(30) DEFAULT NULL,\n"
+                    + "    PRIMARY KEY (`id`),\n"
+                    + "    GLOBAL INDEX /* idx_name_$a870 */ `idx_name` (`name`) PARTITION BY KEY (`name`, `id`) PARTITIONS 16,\n"
+                    + "    LOCAL KEY `_local_idx_name` (`name`)\n"
+                    + ") ENGINE = InnoDB DEFAULT CHARSET = utf8\n"
+                    + "PARTITION BY KEY(`id`)\n"
+                    + "PARTITIONS 16");
+            c.createStatement()
+                .execute("insert into " + tblName + "(id, bid, name) values(1, 11, 'a')");
+            c.createStatement().execute("set partition_hint='P1'");
+
+            c.createStatement().execute("insert into " + tblName + "(id, bid, name) values(2, 12, 'a')");
+
+            Assert.fail("should report error");
+        } catch (SQLException e) {
+            Assert.assertTrue(
+                e.getMessage().contains("[ERR_GLOBAL_SECONDARY_INDEX_MODIFY_GSI_TABLE_DIRECTLY]"));
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+    }
+
+    /**
+     * partition hint with dml on table with gsi should report error.
+     */
+    @Test
+    public void testDmlWithShardingGsi() throws SQLException {
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("drop database if exists partition_hint_test");
+            c.createStatement().execute("create database if not exists partition_hint_test mode=drds");
+            c.createStatement().execute("use partition_hint_test");
+            Random r = new Random();
+            String tblName = "session_hint_dml_test_tb_order_" + r.nextInt(10000);
+            c.createStatement().execute(
+                "CREATE TABLE " + tblName + "(\n"
+                    + "    `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"
+                    + "    `bid` int(11) DEFAULT NULL,\n"
+                    + "    `name` varchar(30) DEFAULT NULL,\n"
+                    + "    PRIMARY KEY (`id`),\n"
+                    + "    GLOBAL INDEX /* idx_name_$a870 */ `idx_name` (`name`) dbpartition by hash(`name`),\n"
+                    + "    LOCAL KEY `_local_idx_name` (`name`)\n"
+                    + ") ENGINE = InnoDB DEFAULT CHARSET = utf8\n"
+                    + "dbpartition by hash(name)");
+            c.createStatement()
+                .execute("insert into " + tblName + "(id, bid, name) values(1, 11, 'a')");
+            c.createStatement().execute("set partition_hint='PARTITION_HINT_TEST_000000_GROUP'");
+
+            c.createStatement().execute("insert into " + tblName + "(id, bid, name) values(2, 12, 'a')");
+
+            Assert.fail("should report error");
+        } catch (SQLException e) {
+            Assert.assertTrue(
+                e.getMessage().contains("[ERR_GLOBAL_SECONDARY_INDEX_MODIFY_GSI_TABLE_DIRECTLY]"));
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+    }
+
+    /**
+     * partition hint with dml on table with gsi should report error.
+     */
+    @Test
+    public void testDmlWithShardingBroadcast() throws SQLException {
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("drop database if exists partition_hint_test");
+            c.createStatement().execute("create database if not exists partition_hint_test mode=drds");
+            c.createStatement().execute("use partition_hint_test");
+            Random r = new Random();
+            String tblName = "session_hint_dml_test_tb_order_" + r.nextInt(10000);
+            c.createStatement().execute(
+                "CREATE TABLE " + tblName + "(\n"
+                    + "    `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"
+                    + "    `bid` int(11) DEFAULT NULL,\n"
+                    + "    `name` varchar(30) DEFAULT NULL,\n"
+                    + "    PRIMARY KEY (`id`)\n"
+                    + ") ENGINE = InnoDB DEFAULT CHARSET = utf8\n"
+                    + "broadcast");
+            c.createStatement()
+                .execute("insert into " + tblName + "(id, bid, name) values(1, 11, 'a')");
+            c.createStatement().execute("set partition_hint='PARTITION_HINT_TEST_SINGLE_GROUP'");
+
+            c.createStatement().execute("insert into " + tblName + "(id, bid, name) values(2, 12, 'a')");
+
+            Assert.fail("should report error");
+        } catch (SQLException e) {
+            e.printStackTrace();
+            Assert.assertTrue(
+                e.getMessage().contains("[ERR_MODIFY_BROADCAST_TABLE_BY_HINT_NOT_ALLOWED]"));
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            log.info("session hint test end");
+        }
+    }
+
+    /**
+     * test prepare path with partition hint
+     */
+    @Test
+    public void testPrepareDml() throws SQLException {
+        Connection c = null;
+        try {
+            c = getPolardbxConnection();
+            c.createStatement().execute("drop database if exists partition_hint_test");
+            c.createStatement().execute("create database if not exists partition_hint_test mode=auto");
+            c.createStatement().execute("use partition_hint_test");
+            // create table into table group partition_test_tg1
+            c.createStatement().execute("CREATE TABLE if not exists `partition_hint_test_tbl1` (\n"
+                + "        `id` bigint NOT NULL,\n"
+                + "        `name` varchar(25) NOT NULL,\n"
+                + "        `c_time` datetime NOT NULL\n"
+                + ") ENGINE = InnoDB DEFAULT CHARSET = utf8mb4  \n"
+                + "PARTITION BY RANGE(YEAR(c_time))\n"
+                + "(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,\n"
+                + " PARTITION p1 VALUES LESS THAN (2000) ENGINE = InnoDB,\n"
+                + " PARTITION p2 VALUES LESS THAN (2010) ENGINE = InnoDB,\n"
+                + " PARTITION p3 VALUES LESS THAN (2020) ENGINE = InnoDB);");
+
+            c.createStatement().execute("CREATE TABLE if not exists `partition_hint_test_tbl2` (\n"
+                + "        `id` bigint NOT NULL,\n"
+                + "        `name` varchar(25) NOT NULL,\n"
+                + "        `c_time` datetime NOT NULL\n"
+                + ") ENGINE = InnoDB DEFAULT CHARSET = utf8mb4  \n"
+                + "PARTITION BY RANGE(YEAR(c_time))\n"
+                + "(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,\n"
+                + " PARTITION p1 VALUES LESS THAN (2000) ENGINE = InnoDB,\n"
+                + " PARTITION p2 VALUES LESS THAN (2010) ENGINE = InnoDB,\n"
+                + " PARTITION p3 VALUES LESS THAN (2020) ENGINE = InnoDB);");
+
+            c.createStatement().executeQuery("set partition_hint='p1'");
+            // test insert
+            PreparedStatement ps =
+                c.prepareStatement("insert into partition_hint_test_tbl1(id, name, c_time) values(?, ?, ?)");
+
+            ps.setInt(1, 5);
+            ps.setString(2, "a");
+            ps.setTimestamp(3, new Timestamp(System.currentTimeMillis()));
+
+            int affectRows = ps.executeUpdate();
+
+            Assert.assertTrue(affectRows == 1);
+            ps.close();
+
+            // test insert batch
+            c.createStatement().executeQuery("set partition_hint='p2'");
+            ps = c.prepareStatement("insert into partition_hint_test_tbl1(id, name, c_time) values(?, ?, ?)");
+
+            ps.setInt(1, 5);
+            ps.setString(2, "a");
+            ps.setTimestamp(3, new Timestamp(System.currentTimeMillis()));
+
+            ps.addBatch();
+
+            ps.setInt(1, 6);
+            ps.setString(2, "b");
+            ps.setTimestamp(3, new Timestamp(System.currentTimeMillis()));
+
+            ps.addBatch();
+
+            ps.executeBatch();
+            ps.close();
+
+            ResultSet rs = c.createStatement().executeQuery("select count(1) from partition_hint_test_tbl1");
+            Assert.assertTrue(rs.next());
+            Assert.assertTrue(2 == rs.getInt(1));
+
+            // test insert multi
+            c.createStatement().executeQuery("set partition_hint='p3'");
+            ps = c.prepareStatement("insert into partition_hint_test_tbl1(id, name, c_time) values(?, ?, ?),(?, ?, ?)");
+
+            ps.setInt(1, 5);
+            ps.setString(2, "a");
+            ps.setTimestamp(3, new Timestamp(System.currentTimeMillis()));
+            ps.setInt(4, 6);
+            ps.setString(5, "b");
+            ps.setTimestamp(6, new Timestamp(System.currentTimeMillis()));
+
+            affectRows = ps.executeUpdate();
+
+            Assert.assertTrue(affectRows == 2);
+            ps.close();
+
+            c.createStatement().executeQuery("set partition_hint=''");
+            rs = c.createStatement().executeQuery("select count(1) from partition_hint_test_tbl1");
+            Assert.assertTrue(rs.next());
+            Assert.assertTrue(5 == rs.getInt(1));
+            // test insert select
+            c.createStatement().executeQuery("set partition_hint='p3'");
+            c.createStatement().execute("insert into partition_hint_test_tbl2 select * from partition_hint_test_tbl1");
+
+            rs = c.createStatement().executeQuery("select count(1) from partition_hint_test_tbl2");
+            Assert.assertTrue(rs.next());
+            Assert.assertTrue(2 == rs.getInt(1));
+
+            c.createStatement().executeQuery("set partition_hint='p2'");
+            rs = c.createStatement().executeQuery("select count(1) from partition_hint_test_tbl2");
+            Assert.assertTrue(rs.next());
+            Assert.assertTrue(0 == rs.getInt(1));
+        } finally {
+            Objects.requireNonNull(c).createStatement().execute("set partition_hint=''");
+            Objects.requireNonNull(c).createStatement().execute("drop database if exists partition_hint_test");
             log.info("session hint test end");
         }
     }


### PR DESCRIPTION
partition hint wont replace physical table name on direct hint add error code 4529 for partition hint
repalce phy table name visitor support flash back& as alias support `show full connection` command, showing partition hint for each session. support replace flashback physical table name in direct mode add some constraint for partition hint, like
  sharding tables must have the same sharding table num in target group   auto tables must be in the same table group
  partition hint won't affect broadcast table

# Problems solved in this PR

# Changes proposed in this PR

# Tests
- [ ] Unit test
- [ ] DML_DDL test

## Release note
> None
