### PR TITLE
Specify version for hydromatic-resource-maven-plugin to solve cannot resolve plugin error

### DIFF
--- a/polardbx-calcite/pom.xml
+++ b/polardbx-calcite/pom.xml
@@ -278,6 +278,7 @@ limitations under the License.
             <plugin>
                 <groupId>net.hydromatic</groupId>
                 <artifactId>hydromatic-resource-maven-plugin</artifactId>
+                <version>0.6</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
# Problems solved in this PR

When I open PolarDB-X with IDEA, I get `Cannot resolve plugin net.hydromatic:hydromatic-resource-maven-plugin:<unknown>` because the plugin version is not specified.

# Changes proposed in this PR

Specify the version for `net.hydromatic:hydromatic-resource-maven-plugin`, version `0.6` is referenced from the maven repository - https://mvnrepository.com/artifact/net.hydromatic/hydromatic-resource-maven-plugin/0.6

# Tests
- [ ] Unit test: No need
- [ ] DML_DDL test: No need

## Release note
> None
